### PR TITLE
Adds "Troubleshooting" section to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,6 +289,7 @@ We wrote a [detailed guide](https://github.com/Kvitekvist/FUS/wiki/Performance-a
 
 
 # Troubleshooting
+
 The [Discord bot](https://discord.com/channels/874974449403826197/916605844261572609) has a list of handy commands with instructions on how to overcome common problems.  If none of these resolve your issue, the Discord has a [support channel](https://discord.com/channels/874974449403826197/874974569373528104) for questions about unmodified FUS modlists of the most current version.
 
 

--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ FUS does not support pirated versions of the game. Do not attempt to install it 
   - [Noteworthy gameplay mods](#noteworthy-gameplay-mods) 
 - [Performance adjustment](#performance-adjustment)
 - [FAQ](#faq)
+- [Troubleshooting](#troubleshooting)
 - [Updating FUS](#updating-fus)
   - [Removing FUS](#removing-fus)
 - [Changelog](#changelog)

--- a/README.md
+++ b/README.md
@@ -288,6 +288,10 @@ We wrote a [detailed guide](https://github.com/Kvitekvist/FUS/wiki/Performance-a
 * I added / changed some mods. What are your settings for rerunning DynDoLOD and Synthesis? -> You can find them [in the wiki](https://github.com/Kvitekvist/FUS/wiki/Settings-for-tools-(LODs-and-Synthesis)).
 
 
+# Troubleshooting
+The [Discord bot](https://discord.com/channels/874974449403826197/916605844261572609) has a list of handy commands with instructions on how to overcome common problems.  If none of these resolve your issue, the Discord has a [support channel](https://discord.com/channels/874974449403826197/874974569373528104) for questions about unmodified FUS modlists of the most current version.
+
+
 # Updating FUS
 
 If this Modlist receives an update please check the changelog before doing anything. Always backup your saves or start a new game after updating.


### PR DESCRIPTION
As per [discord discussion](https://discord.com/channels/874974449403826197/990623521191374848), there's no newbie-friendly link to the existing troubleshooting guides available bot commands.  This PR adds the common "Troubleshooting" section heading to the GitHub readme, to more easily guide people to where they need to be if they have issues.
